### PR TITLE
[CHORE] Line Item Prices

### DIFF
--- a/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
+++ b/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
@@ -175,6 +175,14 @@ Spree.singlePageCheckout.updateOrderSummary = function(data) {
     }
   });
 
+  // Mutate the data a little bit... we need the total amount for each variable
+  // (price * quantity)
+  $.each(data.shipments, function(i, shipment) {
+    $.each(shipment.manifest, function(j, manifest_item) {
+      manifest_item.display_amount = manifest_item.quantity * manifest_item.variant.price;
+    });
+  });
+
   // Update the shipping options
   var shipmentTemplate = Handlebars.compile($('#checkout-shipment-template').html());
   $('#line-items').html('');

--- a/app/views/spree/checkout/_single_page_checkout.html.erb
+++ b/app/views/spree/checkout/_single_page_checkout.html.erb
@@ -123,7 +123,7 @@
         {{variant.name}}
       </div>
       <div class="col-xs-12 col-sm-3 col-md-3 right-text">
-        {{variant.display_price}}
+        ${{display_amount}}
       </div>
     </div>
   {{/each}}

--- a/spec/features/single_page_checkout_spec.rb
+++ b/spec/features/single_page_checkout_spec.rb
@@ -24,7 +24,7 @@ describe 'Single Page Checkout', type: :feature, js: true do
   end
 
   before :each do
-    stock_location.stock_items.update_all(count_on_hand: 1)
+    stock_location.stock_items.update_all(count_on_hand: 2)
     add_mug_to_cart
     Spree::Order.last.update_column(:email, "test@example.com")
     click_button "Checkout"
@@ -82,6 +82,19 @@ describe 'Single Page Checkout', type: :feature, js: true do
   it 'Displays addons in order summary' do
     expect(find('.checkout-addons')).
       to have_content(warranty.name)
+  end
+
+  context 'when there is more than one of the same item in a shipment' do
+    before do
+      add_mug_to_cart # Add a second mug to the order
+      click_button 'Checkout'
+      fill_in_address
+      wait_for_ajax
+    end
+
+    it 'displays an amount that is equal to quantity x price' do
+      expect(find('#line-items')).to have_content(mug.price * 2)
+    end
   end
 
   context 'when addon chosen and the address is filled out', order: :defined do


### PR DESCRIPTION
Status
------
**READY**

Description
-----------
Make manifest items display an amount that reflects the quantity ordered.

Purpose
-------
- [x] Manipulate Spree API data to get the display amount
- [x] Replace the field called in the Handlebars template


Deploy Notes
-----
Run `bundle update --source spree_single_page_checkout` after merge to `2-2-stable`