### PR TITLE
Upgrade for Spree 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
-# gem 'rails', '4.1.9'
-gem 'spree_core', '2.3.10.beta'
-gem 'spree', github: 'spree/spree', branch: '2-3-stable'
+gem 'rails', '4.2.0'
+gem 'spree_core', '3.0.0'
+gem 'spree', github: 'spree/spree', branch: '3-0-stable'
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-3-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-0-stable'
 gem 'jquery-ui-rails'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '2-2-stable'
+# gem 'rails', '4.1.9'
+gem 'spree_core', '2.3.10.beta'
+gem 'spree', github: 'spree/spree', branch: '2-3-stable'
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-2-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-3-stable'
 gem 'jquery-ui-rails'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Dependencies
 
 Includes
 ----------
-jquery-ui-autocomplete
-jquery-ui-effect-shake
+jquery-ui
 jquery.payment
 jquery.h5validate
 jquery.select-to-autocomplete

--- a/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
+++ b/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
@@ -2,9 +2,7 @@
 //= require handlebars-v2.0.0
 //= require jquery.payment
 //= require jquery.h5validate
-//= require jquery.ui.autocomplete
-//= require jquery-ui-effect-shake.min
-//= require jquery.select-to-autocomplete.min
+//= require jquery-ui
 
 // ================================================= //
 //  Javascript  for Single Page Checkout extension   //

--- a/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
+++ b/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
@@ -671,7 +671,7 @@ $(document).ready(function() {
     $('#verification_value').payment('formatCardCVC');
 
     // Country Selector
-    $('#address_country_id').selectToAutocomplete();
+    $('.country').selectToAutocomplete();
 
     // Show / Hide the billing address info when the checkbox is clicked
     Spree.singlePageCheckout.useSameAddress = true;

--- a/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
+++ b/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
@@ -394,8 +394,9 @@ Spree.singlePageCheckout.apiRequest = function(data) {
     '<span>Updating your order...</span></div>'
   );
 
-  var url = '/api/checkouts/' + Spree.current_order_id ;
+  var url = '/api/checkouts/' + Spree.current_order_id;
   data.order_token = Spree.current_order_token;
+  data.template = 'spree/api/orders/show_with_manifest';
   $.ajax({
     url: url,
     method: 'PUT',

--- a/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
+++ b/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
@@ -672,7 +672,7 @@ $(document).ready(function() {
     $('#verification_value').payment('formatCardCVC');
 
     // Country Selector
-    $('.country').selectToAutocomplete();
+    $('#address_country_id').selectToAutocomplete();
 
     // Show / Hide the billing address info when the checkbox is clicked
     Spree.singlePageCheckout.useSameAddress = true;

--- a/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
+++ b/app/assets/javascripts/spree/frontend/spree_single_page_checkout.js
@@ -3,6 +3,7 @@
 //= require jquery.payment
 //= require jquery.h5validate
 //= require jquery-ui
+//= require jquery.select-to-autocomplete.min
 
 // ================================================= //
 //  Javascript  for Single Page Checkout extension   //

--- a/app/assets/stylesheets/spree/frontend/spree_single_page_checkout.css.scss
+++ b/app/assets/stylesheets/spree/frontend/spree_single_page_checkout.css.scss
@@ -2,7 +2,7 @@
 // the installer will append this file to the app vendored assets here:
 // 'vendor/assets/stylesheets/spree/frontend/all.css'
 //
-//= require jquery.ui.autocomplete
+//= require jquery-ui
 
 $boombotixRegular: "TwCenMT-Regular", "Futura", "Century Gothic", Arial, sans-serif !default;
 $boombotixBold: "TwCenMT-Bold", "Futura", "Century Gothic", Arial, sans-serif !default;

--- a/app/views/spree/api/orders/show_with_manifest.v1.rabl
+++ b/app/views/spree/api/orders/show_with_manifest.v1.rabl
@@ -1,0 +1,55 @@
+object @order
+extends "spree/api/orders/order"
+
+if lookup_context.find_all("spree/api/orders/#{root_object.state}").present?
+  extends "spree/api/orders/#{root_object.state}"
+end
+
+child :billing_address => :bill_address do
+  extends "spree/api/addresses/show"
+end
+
+child :shipping_address => :ship_address do
+  extends "spree/api/addresses/show"
+end
+
+child :line_items => :line_items do
+  extends "spree/api/line_items/show"
+end
+
+child :payments => :payments do
+  attributes *payment_attributes
+
+  child :payment_method => :payment_method do
+    attributes :id, :name
+  end
+
+  child :source => :source do
+    attributes *payment_source_attributes
+    if @current_user_roles.include?('admin')
+      attributes *payment_source_attributes.concat([:gateway_customer_profile_id, :gateway_payment_profile_id])
+    else
+      attributes *payment_source_attributes
+    end
+  end
+end
+
+# This is the only difference from the regualr Spree API... we need ALL of the
+# shipment info for the SPC.
+child :shipments => :shipments do
+  extends "spree/api/shipments/show"
+end
+
+child :adjustments => :adjustments do
+  extends "spree/api/adjustments/show"
+end
+
+# Necessary for backend's order interface
+node :permissions do
+  { can_update: current_ability.can?(:update, root_object) }
+end
+
+child :valid_credit_cards => :credit_cards do
+  extends "spree/api/credit_cards/show"
+end
+

--- a/spree_single_page_checkout.gemspec
+++ b/spree_single_page_checkout.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_single_page_checkout'
-  s.version     = '2.3.0'
+  s.version     = '3.0.0'
   s.summary     = 'Single Page Checkout for the Boombotix store'
   s.required_ruby_version = '>= 1.9.3'
 
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '2.3.10.beta'
+  s.add_dependency 'spree_core', '3.0.0'
   s.add_dependency 'bootstrap-sass',  '~> 3'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
 

--- a/spree_single_page_checkout.gemspec
+++ b/spree_single_page_checkout.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_single_page_checkout'
-  s.version     = '2.2.2'
+  s.version     = '2.3.0'
   s.summary     = 'Single Page Checkout for the Boombotix store'
   s.required_ruby_version = '>= 1.9.3'
 
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2.2'
+  s.add_dependency 'spree_core', '2.3.10.beta'
   s.add_dependency 'bootstrap-sass',  '~> 3'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
 


### PR DESCRIPTION
## Status

**READY**
## Description

Upgrade the single page checkout for compatibility with Spree 3.0
**THIS WILL BE THE HEAD FOR THE `3-0-stable` BRANCH**
## Purpose
- [x] Update dependencies
- [x] Make adjustments for changes to the Spree API
## Deploy Notes

None
